### PR TITLE
feat: add remote skill fetch flow

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -3,6 +3,7 @@ use crate::core::jwt;
 use crate::core::manifest::{ManifestRegistry, Provider, Tool};
 use crate::core::scope::{self, ScopeConfig};
 use crate::core::skill::SkillRegistry;
+use crate::core::skillati::{RemoteSkillMeta, SkillAtiClient};
 use crate::proxy::client as proxy_client;
 use crate::Cli;
 use std::process::{Command, Stdio};
@@ -220,11 +221,20 @@ async fn execute_local(
     let skill_registry = SkillRegistry::load(&skills_dir)
         .unwrap_or_else(|_| SkillRegistry::load(std::path::Path::new("/nonexistent")).unwrap());
 
+    let remote_query = scope_name
+        .as_ref()
+        .map(|scope| format!("{scope} {query}"))
+        .unwrap_or_else(|| query.clone());
+    let remote_skills_section =
+        build_remote_skillati_section(&keyring, &remote_query, 12, cli.verbose).await;
+
     // Build system prompt — scoped vs unscoped
     let (system_prompt, scoped_tools) = if let Some(ref tool_name) = scope_name {
         // For scoped mode, find skills for the specific tool/provider
-        let skills_section =
-            build_skills_for_tools(&skill_registry, &[tool_name.as_str()], cli.verbose);
+        let skills_section = merge_skill_sections(&[
+            build_skills_for_tools(&skill_registry, &[tool_name.as_str()], cli.verbose),
+            remote_skills_section.clone(),
+        ]);
         build_scoped_context(tool_name, &registry, &skills_section, cli.verbose)?
     } else {
         // Unscoped: all public tools, pre-filtered by query
@@ -235,7 +245,10 @@ async fn execute_local(
 
         // Find skills for the pre-filtered tools (not just JWT scopes)
         let tool_names: Vec<&str> = scoped.iter().map(|(_, t)| t.name.as_str()).collect();
-        let skills_section = build_skills_for_tools(&skill_registry, &tool_names, cli.verbose);
+        let skills_section = merge_skill_sections(&[
+            build_skills_for_tools(&skill_registry, &tool_names, cli.verbose),
+            remote_skills_section.clone(),
+        ]);
 
         let prompt = HELP_SYSTEM_PROMPT
             .replace("{tools}", &tools_context)
@@ -802,6 +815,81 @@ fn add_skill_content(
     }
 }
 
+async fn build_remote_skillati_section(
+    keyring: &crate::core::keyring::Keyring,
+    query: &str,
+    limit: usize,
+    verbose: bool,
+) -> String {
+    let client = match SkillAtiClient::from_env(keyring) {
+        Ok(Some(client)) => client,
+        Ok(None) => return String::new(),
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to initialize SkillATI catalog for assist");
+            return String::new();
+        }
+    };
+
+    let catalog = match client.catalog().await {
+        Ok(catalog) => catalog,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to load SkillATI catalog for assist");
+            return String::new();
+        }
+    };
+
+    let matched = SkillAtiClient::filter_catalog(&catalog, query, limit);
+    if matched.is_empty() {
+        return String::new();
+    }
+
+    if verbose {
+        tracing::debug!(
+            query = %query,
+            returned = matched.len(),
+            total = catalog.len(),
+            "loaded SkillATI remote catalog for assist"
+        );
+    }
+
+    render_remote_skillati_section(&matched, catalog.len())
+}
+
+fn render_remote_skillati_section(skills: &[RemoteSkillMeta], total_catalog: usize) -> String {
+    let mut section = String::from("## Remote Skills Available Via SkillATI\n\n");
+    section.push_str(
+        "These skills are available remotely from the SkillATI registry. They are not installed locally. Activate one on demand with `ati skillati read <name>`, inspect bundled paths with `ati skillati resources <name>`, and fetch specific files with `ati skillati cat <name> <path>`.\n\n",
+    );
+
+    for skill in skills {
+        section.push_str(&format!("- **{}**: {}\n", skill.name, skill.description));
+    }
+
+    if total_catalog > skills.len() {
+        section.push_str(&format!(
+            "\nOnly the most relevant {} remote skills are shown here.\n",
+            skills.len()
+        ));
+    }
+
+    section
+}
+
+fn merge_skill_sections(sections: &[String]) -> String {
+    sections
+        .iter()
+        .filter_map(|section| {
+            let trimmed = section.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
 /// Pre-filter tools by fuzzy matching against the query.
 /// Returns up to `limit` tools, sorted by relevance score (best first).
 /// If fewer than `limit` tools match (score > 0), all tools are returned up to the limit.
@@ -967,10 +1055,19 @@ async fn execute_plan_mode(
             crate::core::skill::SkillRegistry::load(std::path::Path::new("/nonexistent")).unwrap()
         });
 
+    let remote_query = scope_name
+        .as_ref()
+        .map(|scope| format!("{scope} {query}"))
+        .unwrap_or_else(|| query.clone());
+    let remote_skills_section =
+        build_remote_skillati_section(&keyring, &remote_query, 12, cli.verbose).await;
+
     // Build system prompt — similar to normal assist but with plan suffix
     let (system_prompt, _scoped_tools) = if let Some(ref tool_name) = scope_name {
-        let skills_section =
-            build_skills_for_tools(&skill_registry, &[tool_name.as_str()], cli.verbose);
+        let skills_section = merge_skill_sections(&[
+            build_skills_for_tools(&skill_registry, &[tool_name.as_str()], cli.verbose),
+            remote_skills_section.clone(),
+        ]);
         build_scoped_context(tool_name, &registry, &skills_section, cli.verbose)?
     } else {
         let all_tools = registry.list_public_tools();
@@ -979,7 +1076,10 @@ async fn execute_plan_mode(
         let scoped = prefilter_tools_by_query(&scoped, &query, 50);
         let tools_context = build_tool_context(&scoped, false);
         let tool_names: Vec<&str> = scoped.iter().map(|(_, t)| t.name.as_str()).collect();
-        let skills_section = build_skills_for_tools(&skill_registry, &tool_names, cli.verbose);
+        let skills_section = merge_skill_sections(&[
+            build_skills_for_tools(&skill_registry, &tool_names, cli.verbose),
+            remote_skills_section.clone(),
+        ]);
         let prompt = HELP_SYSTEM_PROMPT
             .replace("{tools}", &tools_context)
             .replace("{skills_section}", &skills_section);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ pub mod init;
 pub mod keys;
 pub mod plan;
 pub mod provider;
+pub mod skillati;
 pub mod skills;
 pub mod token;
 pub mod tools;

--- a/src/cli/skillati.rs
+++ b/src/cli/skillati.rs
@@ -1,0 +1,285 @@
+use crate::cli::common;
+use crate::core::skillati::{
+    build_catalog_manifest, default_catalog_index_path, RemoteSkillMeta, SkillAtiActivation,
+    SkillAtiClient, SkillAtiError, SkillAtiFile, SkillAtiFileData,
+};
+use crate::proxy::client as proxy_client;
+use crate::{Cli, OutputFormat, SkillAtiCommands};
+use std::path::Path;
+
+/// Execute: ati skillati <subcommand>
+pub async fn execute(
+    cli: &Cli,
+    subcmd: &SkillAtiCommands,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let SkillAtiCommands::BuildIndex {
+        source_dir,
+        output_file,
+    } = subcmd
+    {
+        return execute_build_index(cli, source_dir, output_file.as_deref());
+    }
+
+    if let Ok(proxy_url) = std::env::var("ATI_PROXY_URL") {
+        return execute_via_proxy(cli, subcmd, &proxy_url).await;
+    }
+
+    let ati_dir = common::ati_dir();
+    let keyring = crate::cli::call::load_keyring(&ati_dir);
+    let client = SkillAtiClient::from_env(&keyring)?.ok_or(SkillAtiError::NotConfigured)?;
+
+    match subcmd {
+        SkillAtiCommands::Catalog { search } => {
+            let mut catalog = client.catalog().await?;
+            if let Some(query) = search {
+                catalog = SkillAtiClient::filter_catalog(&catalog, query, 25);
+            }
+            print_catalog(cli, &catalog)?;
+        }
+        SkillAtiCommands::Read { name } => {
+            let activation = client.read_skill(name).await?;
+            print_activation(cli, &activation)?;
+        }
+        SkillAtiCommands::Resources { name, prefix } => {
+            let resources = client.list_resources(name, prefix.as_deref()).await?;
+            print_resources(cli, name, prefix.as_deref(), &resources)?;
+        }
+        SkillAtiCommands::Cat { name, path } => {
+            let file = client.read_path(name, path).await?;
+            print_file(cli, &file)?;
+        }
+        SkillAtiCommands::Refs { name } => {
+            let references = client.list_references(name).await?;
+            print_refs(cli, name, &references)?;
+        }
+        SkillAtiCommands::Ref { name, reference } => {
+            let file = client
+                .read_path(name, &format!("references/{reference}"))
+                .await?;
+            print_file(cli, &file)?;
+        }
+        SkillAtiCommands::BuildIndex { .. } => unreachable!(),
+    }
+
+    Ok(())
+}
+
+async fn execute_via_proxy(
+    cli: &Cli,
+    subcmd: &SkillAtiCommands,
+    proxy_url: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match subcmd {
+        SkillAtiCommands::Catalog { search } => {
+            let response = proxy_client::get_skillati_catalog(proxy_url, search.as_deref()).await?;
+            let catalog: Vec<RemoteSkillMeta> =
+                serde_json::from_value(response.get("skills").cloned().ok_or_else(|| {
+                    "Proxy returned invalid SkillATI catalog response".to_string()
+                })?)?;
+            print_catalog(cli, &catalog)?;
+        }
+        SkillAtiCommands::Read { name } => {
+            let response = proxy_client::get_skillati_read(proxy_url, name).await?;
+            let activation: SkillAtiActivation = serde_json::from_value(response)?;
+            print_activation(cli, &activation)?;
+        }
+        SkillAtiCommands::Resources { name, prefix } => {
+            let response =
+                proxy_client::get_skillati_resources(proxy_url, name, prefix.as_deref()).await?;
+            let resources: Vec<String> =
+                serde_json::from_value(response.get("resources").cloned().ok_or_else(|| {
+                    "Proxy returned invalid SkillATI resources response".to_string()
+                })?)?;
+            print_resources(cli, name, prefix.as_deref(), &resources)?;
+        }
+        SkillAtiCommands::Cat { name, path } => {
+            let response = proxy_client::get_skillati_file(proxy_url, name, path).await?;
+            let file: SkillAtiFile = serde_json::from_value(response)?;
+            print_file(cli, &file)?;
+        }
+        SkillAtiCommands::Refs { name } => {
+            let response = proxy_client::get_skillati_refs(proxy_url, name).await?;
+            let references: Vec<String> = serde_json::from_value(
+                response
+                    .get("references")
+                    .cloned()
+                    .ok_or_else(|| "Proxy returned invalid SkillATI refs response".to_string())?,
+            )?;
+            print_refs(cli, name, &references)?;
+        }
+        SkillAtiCommands::Ref { name, reference } => {
+            let response = proxy_client::get_skillati_file(
+                proxy_url,
+                name,
+                &format!("references/{reference}"),
+            )
+            .await?;
+            let file: SkillAtiFile = serde_json::from_value(response)?;
+            print_file(cli, &file)?;
+        }
+        SkillAtiCommands::BuildIndex { .. } => unreachable!(),
+    }
+
+    Ok(())
+}
+
+fn execute_build_index(
+    cli: &Cli,
+    source_dir: &str,
+    output: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let manifest = build_catalog_manifest(Path::new(source_dir))?;
+    let json = serde_json::to_string_pretty(&manifest)?;
+
+    if let Some(path) = output {
+        std::fs::write(path, &json)?;
+        match cli.output {
+            OutputFormat::Json => {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "output": path,
+                        "skills": manifest.skills.len(),
+                        "recommended_object": default_catalog_index_path(),
+                    }))?
+                );
+            }
+            _ => {
+                println!(
+                    "Wrote SkillATI catalog manifest for {} skills to {}",
+                    manifest.skills.len(),
+                    path
+                );
+                println!(
+                    "Recommended GCS object path: {}",
+                    default_catalog_index_path()
+                );
+            }
+        }
+        return Ok(());
+    }
+
+    println!("{json}");
+    Ok(())
+}
+
+fn print_catalog(cli: &Cli, catalog: &[RemoteSkillMeta]) -> Result<(), Box<dyn std::error::Error>> {
+    match cli.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({ "skills": catalog }))?
+            );
+        }
+        _ => {
+            for skill in catalog {
+                println!("{}: {}", skill.name, skill.description);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_activation(
+    cli: &Cli,
+    activation: &SkillAtiActivation,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match cli.output {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(activation)?);
+        }
+        _ => {
+            println!("{}", render_activation_text(activation));
+        }
+    }
+    Ok(())
+}
+
+fn render_activation_text(activation: &SkillAtiActivation) -> String {
+    let mut out = format!(
+        "<skill_content name=\"{}\">\n{}\n\nSkill directory: {}\n\nBundled resources:\n",
+        activation.name,
+        activation.content.trim_end(),
+        activation.skill_directory
+    );
+
+    if activation.resources.is_empty() {
+        out.push_str("- (none)\n");
+    } else {
+        for resource in &activation.resources {
+            out.push_str(&format!("- {resource}\n"));
+        }
+    }
+
+    out.push_str("</skill_content>");
+    out
+}
+
+fn print_resources(
+    cli: &Cli,
+    name: &str,
+    prefix: Option<&str>,
+    resources: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    match cli.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "name": name,
+                    "prefix": prefix,
+                    "resources": resources,
+                }))?
+            );
+        }
+        _ => {
+            for resource in resources {
+                println!("{resource}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_refs(
+    cli: &Cli,
+    name: &str,
+    references: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    match cli.output {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "name": name,
+                    "references": references,
+                }))?
+            );
+        }
+        _ => {
+            for reference in references {
+                println!("{reference}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_file(cli: &Cli, file: &SkillAtiFile) -> Result<(), Box<dyn std::error::Error>> {
+    match cli.output {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(file)?);
+        }
+        _ => match &file.data {
+            SkillAtiFileData::Text { content } => println!("{content}"),
+            SkillAtiFileData::Binary { .. } => {
+                return Err(format!(
+                    "Path '{}' in skill '{}' is binary; rerun with --output json",
+                    file.path, file.resolved_skill
+                )
+                .into());
+            }
+        },
+    }
+    Ok(())
+}

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use super::common;
+use crate::cli::skillati;
 use crate::core::jwt;
 use crate::core::manifest::ManifestRegistry;
 use crate::core::scope::ScopeConfig;
@@ -99,6 +100,7 @@ pub async fn execute(cli: &Cli, subcmd: &SkillCommands) -> Result<(), Box<dyn st
         SkillCommands::Verify { name } => verify_skill(name),
         SkillCommands::Diff { source } => diff_skill(source).await,
         SkillCommands::Update { name, force } => update_skill(name, *force).await,
+        SkillCommands::Fetch { fetch } => skillati::execute(cli, fetch).await,
     }
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,4 +15,5 @@ pub mod rate;
 pub mod response;
 pub mod scope;
 pub mod skill;
+pub mod skillati;
 pub mod xai;

--- a/src/core/skillati.rs
+++ b/src/core/skillati.rs
@@ -1,0 +1,942 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use base64::Engine;
+use chrono::Utc;
+use futures::stream::{self, StreamExt};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::core::gcs::{GcsClient, GcsError};
+use crate::core::keyring::Keyring;
+use crate::core::skill::{is_anthropic_valid_name, parse_skill_metadata, strip_frontmatter};
+
+const GCS_CREDENTIAL_KEY: &str = "gcp_credentials";
+const DEFAULT_CATALOG_INDEX_PATH: &str = "_skillati/catalog.v1.json";
+const DEFAULT_CATALOG_INDEX_CANDIDATES: &[&str] = &[
+    DEFAULT_CATALOG_INDEX_PATH,
+    "_skillati/catalog.json",
+    "skillati-catalog.json",
+];
+const FALLBACK_CATALOG_CONCURRENCY: usize = 24;
+
+#[derive(Error, Debug)]
+pub enum SkillAtiError {
+    #[error("SkillATI is not configured (set ATI_SKILL_REGISTRY=gcs://<bucket>)")]
+    NotConfigured,
+    #[error("Unsupported skill registry URL: {0}")]
+    UnsupportedRegistry(String),
+    #[error("GCS credentials not found in keyring: {0}")]
+    MissingCredentials(&'static str),
+    #[error("Skill '{0}' not found")]
+    SkillNotFound(String),
+    #[error("Path '{path}' not found in skill '{skill}'")]
+    PathNotFound { skill: String, path: String },
+    #[error("Invalid skill-relative path '{0}'")]
+    InvalidPath(String),
+    #[error(transparent)]
+    Gcs(#[from] GcsError),
+}
+
+#[derive(Error, Debug)]
+pub enum SkillAtiBuildError {
+    #[error("Source directory not found: {0}")]
+    MissingSource(String),
+    #[error("Failed to read {0}: {1}")]
+    Io(String, #[source] std::io::Error),
+    #[error("Failed to parse skill metadata for {0}: {1}")]
+    Metadata(String, String),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemoteSkillMeta {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub skill_directory: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub providers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub categories: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillAtiCatalogEntry {
+    #[serde(flatten)]
+    pub meta: RemoteSkillMeta,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resources: Vec<String>,
+    #[serde(default, skip)]
+    pub resources_complete: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillAtiCatalogManifest {
+    #[serde(default = "default_catalog_version")]
+    pub version: u32,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub generated_at: String,
+    pub skills: Vec<SkillAtiCatalogEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillAtiActivation {
+    pub name: String,
+    pub skill_directory: String,
+    pub content: String,
+    pub resources: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SkillAtiFileData {
+    Text { content: String },
+    Binary { encoding: String, content: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillAtiFile {
+    pub requested_skill: String,
+    pub resolved_skill: String,
+    pub path: String,
+    #[serde(flatten)]
+    pub data: SkillAtiFileData,
+}
+
+pub struct SkillAtiClient {
+    gcs: GcsClient,
+    bytes_cache: Mutex<HashMap<(String, String), Vec<u8>>>,
+    resources_cache: Mutex<HashMap<String, Vec<String>>>,
+    catalog_cache: Mutex<Option<Vec<SkillAtiCatalogEntry>>>,
+}
+
+impl SkillAtiClient {
+    pub fn from_env(keyring: &Keyring) -> Result<Option<Self>, SkillAtiError> {
+        match std::env::var("ATI_SKILL_REGISTRY") {
+            Ok(url) if !url.trim().is_empty() => Ok(Some(Self::from_registry_url(&url, keyring)?)),
+            _ => Ok(None),
+        }
+    }
+
+    pub fn from_registry_url(registry_url: &str, keyring: &Keyring) -> Result<Self, SkillAtiError> {
+        let bucket = registry_url
+            .strip_prefix("gcs://")
+            .ok_or_else(|| SkillAtiError::UnsupportedRegistry(registry_url.to_string()))?;
+
+        let cred_json = keyring
+            .get(GCS_CREDENTIAL_KEY)
+            .ok_or(SkillAtiError::MissingCredentials(GCS_CREDENTIAL_KEY))?;
+
+        let gcs = GcsClient::new(bucket.to_string(), cred_json)?;
+        Ok(Self {
+            gcs,
+            bytes_cache: Mutex::new(HashMap::new()),
+            resources_cache: Mutex::new(HashMap::new()),
+            catalog_cache: Mutex::new(None),
+        })
+    }
+
+    pub async fn catalog(&self) -> Result<Vec<RemoteSkillMeta>, SkillAtiError> {
+        Ok(self
+            .catalog_entries()
+            .await?
+            .into_iter()
+            .map(|entry| entry.meta)
+            .collect())
+    }
+
+    pub fn filter_catalog(
+        catalog: &[RemoteSkillMeta],
+        query: &str,
+        limit: usize,
+    ) -> Vec<RemoteSkillMeta> {
+        let query = query.trim().to_lowercase();
+        if query.is_empty() {
+            return catalog.iter().take(limit).cloned().collect();
+        }
+
+        let terms: Vec<&str> = query.split_whitespace().collect();
+        let mut scored: Vec<(usize, &RemoteSkillMeta)> = catalog
+            .iter()
+            .map(|skill| {
+                let haystack = search_haystack(skill);
+                let score = terms
+                    .iter()
+                    .filter(|term| haystack.contains(**term))
+                    .count();
+                (score, skill)
+            })
+            .filter(|(score, skill)| *score > 0 || search_haystack(skill).contains(&query))
+            .collect();
+
+        scored.sort_by(|a, b| {
+            b.0.cmp(&a.0)
+                .then_with(|| a.1.name.to_lowercase().cmp(&b.1.name.to_lowercase()))
+        });
+
+        scored
+            .into_iter()
+            .take(limit)
+            .map(|(_, skill)| skill.clone())
+            .collect()
+    }
+
+    pub async fn read_skill(&self, name: &str) -> Result<SkillAtiActivation, SkillAtiError> {
+        let raw = self.read_text(name, "SKILL.md").await?;
+        let resources = self.list_resources(name, None).await?;
+        Ok(SkillAtiActivation {
+            name: name.to_string(),
+            skill_directory: skill_directory(name),
+            content: strip_frontmatter(&raw).to_string(),
+            resources,
+        })
+    }
+
+    pub async fn list_resources(
+        &self,
+        name: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<String>, SkillAtiError> {
+        let resources = self.list_all_resources(name).await?;
+        let normalized_prefix = match prefix {
+            Some(value) if !value.trim().is_empty() => Some(normalize_prefix(value)?),
+            _ => None,
+        };
+
+        let filtered = match normalized_prefix {
+            Some(prefix) => resources
+                .into_iter()
+                .filter(|path| path == &prefix || path.starts_with(&format!("{prefix}/")))
+                .collect(),
+            None => resources,
+        };
+
+        Ok(filtered)
+    }
+
+    pub async fn read_path(
+        &self,
+        requested_skill: &str,
+        requested_path: &str,
+    ) -> Result<SkillAtiFile, SkillAtiError> {
+        let (resolved_skill, resolved_path) =
+            resolve_requested_path(requested_skill, requested_path)?;
+        let bytes = self.read_bytes(&resolved_skill, &resolved_path).await?;
+
+        let data = match String::from_utf8(bytes.clone()) {
+            Ok(text) => SkillAtiFileData::Text { content: text },
+            Err(_) => SkillAtiFileData::Binary {
+                encoding: "base64".to_string(),
+                content: base64::engine::general_purpose::STANDARD.encode(bytes),
+            },
+        };
+
+        Ok(SkillAtiFile {
+            requested_skill: requested_skill.to_string(),
+            resolved_skill,
+            path: resolved_path,
+            data,
+        })
+    }
+
+    pub async fn list_references(&self, name: &str) -> Result<Vec<String>, SkillAtiError> {
+        let refs = self.list_resources(name, Some("references")).await?;
+        Ok(refs
+            .into_iter()
+            .filter_map(|path| path.strip_prefix("references/").map(str::to_string))
+            .collect())
+    }
+
+    pub async fn read_reference(
+        &self,
+        name: &str,
+        reference: &str,
+    ) -> Result<String, SkillAtiError> {
+        let path = format!("references/{reference}");
+        let file = self.read_path(name, &path).await?;
+        match file.data {
+            SkillAtiFileData::Text { content } => Ok(content),
+            SkillAtiFileData::Binary { .. } => Err(SkillAtiError::InvalidPath(path)),
+        }
+    }
+
+    async fn catalog_entries(&self) -> Result<Vec<SkillAtiCatalogEntry>, SkillAtiError> {
+        if let Some(cached) = self.catalog_cache.lock().unwrap().clone() {
+            return Ok(cached);
+        }
+
+        let entries = match self.load_catalog_index().await? {
+            Some(entries) => entries,
+            None => self.load_catalog_fallback().await?,
+        };
+
+        self.catalog_cache.lock().unwrap().replace(entries.clone());
+        Ok(entries)
+    }
+
+    async fn load_catalog_index(&self) -> Result<Option<Vec<SkillAtiCatalogEntry>>, SkillAtiError> {
+        for candidate in catalog_index_candidates() {
+            match self.gcs.get_object_text(&candidate).await {
+                Ok(raw) => match serde_json::from_str::<SkillAtiCatalogManifest>(&raw) {
+                    Ok(mut manifest) => {
+                        for entry in &mut manifest.skills {
+                            normalize_catalog_entry(entry);
+                            entry.resources_complete = true;
+                        }
+                        manifest.skills.sort_by(|a, b| {
+                            a.meta.name.to_lowercase().cmp(&b.meta.name.to_lowercase())
+                        });
+                        tracing::debug!(
+                            path = %candidate,
+                            skills = manifest.skills.len(),
+                            "loaded SkillATI catalog index"
+                        );
+                        return Ok(Some(manifest.skills));
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            path = %candidate,
+                            error = %err,
+                            "SkillATI catalog index was invalid, falling back"
+                        );
+                    }
+                },
+                Err(GcsError::Api { status: 404, .. }) => continue,
+                Err(err) => return Err(SkillAtiError::Gcs(err)),
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn load_catalog_fallback(&self) -> Result<Vec<SkillAtiCatalogEntry>, SkillAtiError> {
+        let mut names = self.gcs.list_skill_names().await?;
+        names.sort();
+
+        let mut entries: Vec<SkillAtiCatalogEntry> = stream::iter(names.into_iter())
+            .map(|name| async move {
+                let raw = self.read_text(&name, "SKILL.md").await?;
+                let parsed = parse_skill_metadata(&name, &raw, None)
+                    .map_err(|e| SkillAtiError::InvalidPath(e.to_string()))?;
+                Ok::<SkillAtiCatalogEntry, SkillAtiError>(SkillAtiCatalogEntry {
+                    meta: remote_skill_meta_from_parts(
+                        &name,
+                        parsed.description,
+                        parsed.keywords,
+                        parsed.tools,
+                        parsed.providers,
+                        parsed.categories,
+                    ),
+                    resources: Vec::new(),
+                    resources_complete: false,
+                })
+            })
+            .buffer_unordered(FALLBACK_CATALOG_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        entries.sort_by(|a, b| a.meta.name.to_lowercase().cmp(&b.meta.name.to_lowercase()));
+        Ok(entries)
+    }
+
+    async fn list_all_resources(&self, name: &str) -> Result<Vec<String>, SkillAtiError> {
+        if let Some(cached) = self.resources_cache.lock().unwrap().get(name).cloned() {
+            return Ok(cached);
+        }
+
+        if let Some(indexed) = self
+            .catalog_entries()
+            .await?
+            .into_iter()
+            .find(|entry| entry.meta.name == name && entry.resources_complete)
+        {
+            self.resources_cache
+                .lock()
+                .unwrap()
+                .insert(name.to_string(), indexed.resources.clone());
+            return Ok(indexed.resources);
+        }
+
+        self.ensure_skill_exists(name).await?;
+
+        let mut resources = self.gcs.list_objects(name).await?;
+        resources.retain(|path| is_visible_resource(path));
+        resources.sort();
+        resources.dedup();
+
+        self.resources_cache
+            .lock()
+            .unwrap()
+            .insert(name.to_string(), resources.clone());
+        Ok(resources)
+    }
+
+    async fn ensure_skill_exists(&self, name: &str) -> Result<(), SkillAtiError> {
+        self.read_bytes(name, "SKILL.md").await.map(|_| ())
+    }
+
+    async fn read_text(&self, name: &str, relative_path: &str) -> Result<String, SkillAtiError> {
+        let bytes = self.read_bytes(name, relative_path).await?;
+        String::from_utf8(bytes).map_err(|e| SkillAtiError::Gcs(GcsError::Utf8(e.to_string())))
+    }
+
+    async fn read_bytes(&self, name: &str, relative_path: &str) -> Result<Vec<u8>, SkillAtiError> {
+        let cache_key = (name.to_string(), relative_path.to_string());
+        if let Some(cached) = self.bytes_cache.lock().unwrap().get(&cache_key).cloned() {
+            return Ok(cached);
+        }
+
+        let gcs_path = format!("{name}/{relative_path}");
+        let bytes = self
+            .gcs
+            .get_object(&gcs_path)
+            .await
+            .map_err(|e| map_gcs_error(name, relative_path, e))?;
+
+        self.bytes_cache
+            .lock()
+            .unwrap()
+            .insert(cache_key, bytes.clone());
+        Ok(bytes)
+    }
+}
+
+pub fn build_catalog_manifest(
+    source_dir: &Path,
+) -> Result<SkillAtiCatalogManifest, SkillAtiBuildError> {
+    if !source_dir.exists() {
+        return Err(SkillAtiBuildError::MissingSource(
+            source_dir.display().to_string(),
+        ));
+    }
+
+    let mut skill_dirs = discover_skill_dirs(source_dir)?;
+    skill_dirs.sort();
+
+    let mut skills = Vec::new();
+    for skill_dir in skill_dirs {
+        skills.push(build_catalog_entry_from_dir(&skill_dir)?);
+    }
+
+    skills.sort_by(|a, b| a.meta.name.to_lowercase().cmp(&b.meta.name.to_lowercase()));
+    Ok(SkillAtiCatalogManifest {
+        version: default_catalog_version(),
+        generated_at: Utc::now().to_rfc3339(),
+        skills,
+    })
+}
+
+pub fn default_catalog_index_path() -> &'static str {
+    DEFAULT_CATALOG_INDEX_PATH
+}
+
+fn default_catalog_version() -> u32 {
+    1
+}
+
+fn catalog_index_candidates() -> Vec<String> {
+    match std::env::var("ATI_SKILL_REGISTRY_INDEX_OBJECT") {
+        Ok(value) => {
+            let candidates: Vec<String> = value
+                .split(',')
+                .map(str::trim)
+                .filter(|candidate| !candidate.is_empty())
+                .map(str::to_string)
+                .collect();
+            if candidates.is_empty() {
+                DEFAULT_CATALOG_INDEX_CANDIDATES
+                    .iter()
+                    .map(|candidate| candidate.to_string())
+                    .collect()
+            } else {
+                candidates
+            }
+        }
+        Err(_) => DEFAULT_CATALOG_INDEX_CANDIDATES
+            .iter()
+            .map(|candidate| candidate.to_string())
+            .collect(),
+    }
+}
+
+fn build_catalog_entry_from_dir(
+    skill_dir: &Path,
+) -> Result<SkillAtiCatalogEntry, SkillAtiBuildError> {
+    let dir_name = skill_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| SkillAtiBuildError::MissingSource(skill_dir.display().to_string()))?
+        .to_string();
+
+    let skill_md_path = skill_dir.join("SKILL.md");
+    let skill_md = fs::read_to_string(&skill_md_path)
+        .map_err(|err| SkillAtiBuildError::Io(skill_md_path.display().to_string(), err))?;
+    let skill_toml_path = skill_dir.join("skill.toml");
+    let skill_toml =
+        if skill_toml_path.exists() {
+            Some(fs::read_to_string(&skill_toml_path).map_err(|err| {
+                SkillAtiBuildError::Io(skill_toml_path.display().to_string(), err)
+            })?)
+        } else {
+            None
+        };
+
+    let parsed = parse_skill_metadata(&dir_name, &skill_md, skill_toml.as_deref())
+        .map_err(|err| SkillAtiBuildError::Metadata(dir_name.clone(), err.to_string()))?;
+    let resources = collect_visible_resources(skill_dir, skill_dir)?;
+
+    Ok(SkillAtiCatalogEntry {
+        meta: remote_skill_meta_from_parts(
+            &dir_name,
+            parsed.description,
+            parsed.keywords,
+            parsed.tools,
+            parsed.providers,
+            parsed.categories,
+        ),
+        resources,
+        resources_complete: true,
+    })
+}
+
+fn discover_skill_dirs(source_dir: &Path) -> Result<Vec<PathBuf>, SkillAtiBuildError> {
+    if source_dir.join("SKILL.md").is_file() {
+        return Ok(vec![source_dir.to_path_buf()]);
+    }
+
+    let mut skill_dirs = Vec::new();
+    let entries = fs::read_dir(source_dir)
+        .map_err(|err| SkillAtiBuildError::Io(source_dir.display().to_string(), err))?;
+
+    for entry in entries {
+        let entry =
+            entry.map_err(|err| SkillAtiBuildError::Io(source_dir.display().to_string(), err))?;
+        let path = entry.path();
+        if path.is_dir() && path.join("SKILL.md").is_file() {
+            skill_dirs.push(path);
+        }
+    }
+
+    Ok(skill_dirs)
+}
+
+fn collect_visible_resources(
+    root: &Path,
+    current: &Path,
+) -> Result<Vec<String>, SkillAtiBuildError> {
+    let mut resources = Vec::new();
+    let entries = fs::read_dir(current)
+        .map_err(|err| SkillAtiBuildError::Io(current.display().to_string(), err))?;
+
+    for entry in entries {
+        let entry =
+            entry.map_err(|err| SkillAtiBuildError::Io(current.display().to_string(), err))?;
+        let path = entry.path();
+        let file_name = entry.file_name();
+        if file_name.to_string_lossy().starts_with('.') {
+            continue;
+        }
+
+        if path.is_dir() {
+            resources.extend(collect_visible_resources(root, &path)?);
+            continue;
+        }
+
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|_| SkillAtiBuildError::MissingSource(path.display().to_string()))?
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        if is_visible_resource(&relative) {
+            resources.push(relative);
+        }
+    }
+
+    resources.sort();
+    resources.dedup();
+    Ok(resources)
+}
+
+fn remote_skill_meta_from_parts(
+    name: &str,
+    description: String,
+    mut keywords: Vec<String>,
+    mut tools: Vec<String>,
+    mut providers: Vec<String>,
+    mut categories: Vec<String>,
+) -> RemoteSkillMeta {
+    dedup_sort_casefold(&mut keywords);
+    dedup_sort_casefold(&mut tools);
+    dedup_sort_casefold(&mut providers);
+    dedup_sort_casefold(&mut categories);
+
+    RemoteSkillMeta {
+        name: name.to_string(),
+        description,
+        skill_directory: skill_directory(name),
+        keywords,
+        tools,
+        providers,
+        categories,
+    }
+}
+
+fn normalize_catalog_entry(entry: &mut SkillAtiCatalogEntry) {
+    if entry.meta.skill_directory.trim().is_empty() {
+        entry.meta.skill_directory = skill_directory(&entry.meta.name);
+    }
+    dedup_sort_casefold(&mut entry.meta.keywords);
+    dedup_sort_casefold(&mut entry.meta.tools);
+    dedup_sort_casefold(&mut entry.meta.providers);
+    dedup_sort_casefold(&mut entry.meta.categories);
+    entry.resources.retain(|path| is_visible_resource(path));
+    entry.resources.sort();
+    entry.resources.dedup();
+}
+
+fn dedup_sort_casefold(values: &mut Vec<String>) {
+    let mut seen = HashSet::new();
+    values.retain(|value| {
+        let normalized = value.trim().to_lowercase();
+        !normalized.is_empty() && seen.insert(normalized)
+    });
+    values.sort_by_key(|value| value.to_lowercase());
+}
+
+fn search_haystack(skill: &RemoteSkillMeta) -> String {
+    let mut parts = vec![skill.name.to_lowercase(), skill.description.to_lowercase()];
+    if !skill.keywords.is_empty() {
+        parts.push(skill.keywords.join(" ").to_lowercase());
+    }
+    if !skill.tools.is_empty() {
+        parts.push(skill.tools.join(" ").to_lowercase());
+    }
+    if !skill.providers.is_empty() {
+        parts.push(skill.providers.join(" ").to_lowercase());
+    }
+    if !skill.categories.is_empty() {
+        parts.push(skill.categories.join(" ").to_lowercase());
+    }
+    parts.join(" ")
+}
+
+fn map_gcs_error(skill: &str, relative_path: &str, error: GcsError) -> SkillAtiError {
+    match error {
+        GcsError::Api { status: 404, .. } if relative_path == "SKILL.md" => {
+            SkillAtiError::SkillNotFound(skill.to_string())
+        }
+        GcsError::Api { status: 404, .. } => SkillAtiError::PathNotFound {
+            skill: skill.to_string(),
+            path: relative_path.to_string(),
+        },
+        other => SkillAtiError::Gcs(other),
+    }
+}
+
+fn skill_directory(name: &str) -> String {
+    format!("skillati://{name}")
+}
+
+fn is_visible_resource(path: &str) -> bool {
+    !path.is_empty()
+        && !path.ends_with('/')
+        && path != "SKILL.md"
+        && path != "skill.toml"
+        && !path.starts_with('.')
+}
+
+fn normalize_prefix(prefix: &str) -> Result<String, SkillAtiError> {
+    let prefix = trim_leading_current_dir(prefix);
+    if prefix.is_empty() {
+        return Err(SkillAtiError::InvalidPath(prefix.to_string()));
+    }
+    normalize_within_skill(prefix)
+}
+
+fn resolve_requested_path(
+    requested_skill: &str,
+    requested_path: &str,
+) -> Result<(String, String), SkillAtiError> {
+    let requested_path = trim_leading_current_dir(requested_path);
+    validate_raw_path(requested_path)?;
+
+    if requested_path == ".." {
+        return Err(SkillAtiError::InvalidPath(requested_path.to_string()));
+    }
+
+    if let Some(rest) = requested_path.strip_prefix("../") {
+        let segments: Vec<&str> = rest
+            .split('/')
+            .filter(|segment| !segment.is_empty() && *segment != ".")
+            .collect();
+        if segments.len() < 2 {
+            return Err(SkillAtiError::InvalidPath(requested_path.to_string()));
+        }
+
+        let sibling_skill = segments[0];
+        if !is_anthropic_valid_name(sibling_skill) {
+            return Err(SkillAtiError::InvalidPath(requested_path.to_string()));
+        }
+
+        let normalized_path = normalize_within_skill(&segments[1..].join("/"))?;
+        return Ok((sibling_skill.to_string(), normalized_path));
+    }
+
+    Ok((
+        requested_skill.to_string(),
+        normalize_within_skill(requested_path)?,
+    ))
+}
+
+fn trim_leading_current_dir(path: &str) -> &str {
+    let mut trimmed = path.trim();
+    while let Some(rest) = trimmed.strip_prefix("./") {
+        trimmed = rest;
+    }
+    trimmed
+}
+
+fn validate_raw_path(path: &str) -> Result<(), SkillAtiError> {
+    if path.trim().is_empty() || path.contains('\0') || path.contains('\\') || path.starts_with('/')
+    {
+        return Err(SkillAtiError::InvalidPath(path.to_string()));
+    }
+    Ok(())
+}
+
+fn normalize_within_skill(path: &str) -> Result<String, SkillAtiError> {
+    validate_raw_path(path)?;
+
+    let mut stack: Vec<&str> = Vec::new();
+    for segment in path.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                if stack.pop().is_none() {
+                    return Err(SkillAtiError::InvalidPath(path.to_string()));
+                }
+            }
+            value => stack.push(value),
+        }
+    }
+
+    if stack.is_empty() {
+        return Err(SkillAtiError::InvalidPath(path.to_string()));
+    }
+
+    Ok(stack.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_catalog_manifest, catalog_index_candidates, collect_visible_resources,
+        default_catalog_index_path, is_visible_resource, map_gcs_error, normalize_within_skill,
+        remote_skill_meta_from_parts, resolve_requested_path, search_haystack, skill_directory,
+        SkillAtiCatalogEntry, SkillAtiError,
+    };
+    use crate::core::gcs::GcsError;
+    use std::fs;
+
+    #[test]
+    fn skill_directory_uses_virtual_scheme() {
+        assert_eq!(skill_directory("demo-skill"), "skillati://demo-skill");
+    }
+
+    #[test]
+    fn normalize_within_skill_rejects_invalid_paths() {
+        assert_eq!(
+            normalize_within_skill("references/guide.md").unwrap(),
+            "references/guide.md"
+        );
+        assert_eq!(
+            normalize_within_skill("./references/./guide.md").unwrap(),
+            "references/guide.md"
+        );
+        assert!(normalize_within_skill("../escape.md").is_err());
+        assert!(normalize_within_skill("references/../../escape.md").is_err());
+        assert!(normalize_within_skill(r"references\guide.md").is_err());
+    }
+
+    #[test]
+    fn resolve_requested_path_supports_sibling_skills() {
+        assert_eq!(
+            resolve_requested_path("react-component-builder", "../ui-design-system/SKILL.md")
+                .unwrap(),
+            ("ui-design-system".to_string(), "SKILL.md".to_string())
+        );
+        assert_eq!(
+            resolve_requested_path(
+                "react-component-builder",
+                "../ui-design-system/references/core-principles.md"
+            )
+            .unwrap(),
+            (
+                "ui-design-system".to_string(),
+                "references/core-principles.md".to_string()
+            )
+        );
+        assert!(matches!(
+            resolve_requested_path("a", "../../etc/passwd"),
+            Err(SkillAtiError::InvalidPath(_))
+        ));
+        assert!(matches!(
+            resolve_requested_path("a", "../bad name/SKILL.md"),
+            Err(SkillAtiError::InvalidPath(_))
+        ));
+    }
+
+    #[test]
+    fn visible_resources_filter_internal_files_and_dirs() {
+        assert!(is_visible_resource("references/guide.md"));
+        assert!(is_visible_resource("assets/logo.png"));
+        assert!(!is_visible_resource("SKILL.md"));
+        assert!(!is_visible_resource("skill.toml"));
+        assert!(!is_visible_resource("references/"));
+    }
+
+    #[test]
+    fn map_404_for_skill_md_becomes_skill_not_found() {
+        let err = map_gcs_error(
+            "demo-skill",
+            "SKILL.md",
+            GcsError::Api {
+                status: 404,
+                message: "nope".into(),
+            },
+        );
+        assert!(matches!(err, SkillAtiError::SkillNotFound(name) if name == "demo-skill"));
+    }
+
+    #[test]
+    fn map_404_for_other_paths_becomes_path_not_found() {
+        let err = map_gcs_error(
+            "demo-skill",
+            "references/guide.md",
+            GcsError::Api {
+                status: 404,
+                message: "nope".into(),
+            },
+        );
+        assert!(
+            matches!(err, SkillAtiError::PathNotFound { skill, path } if skill == "demo-skill" && path == "references/guide.md")
+        );
+    }
+
+    #[test]
+    fn search_haystack_includes_keywords_and_bindings() {
+        let meta = remote_skill_meta_from_parts(
+            "demo-skill",
+            "Great for UI panels".to_string(),
+            vec!["dashboard".into()],
+            vec!["render_panel".into()],
+            vec!["frontend".into()],
+            vec!["design".into()],
+        );
+        let haystack = search_haystack(&meta);
+        assert!(haystack.contains("dashboard"));
+        assert!(haystack.contains("render_panel"));
+        assert!(haystack.contains("frontend"));
+        assert!(haystack.contains("design"));
+    }
+
+    #[test]
+    fn env_override_for_catalog_index_candidates_is_supported() {
+        unsafe {
+            std::env::set_var(
+                "ATI_SKILL_REGISTRY_INDEX_OBJECT",
+                "custom/one.json, custom/two.json",
+            );
+        }
+        assert_eq!(
+            catalog_index_candidates(),
+            vec!["custom/one.json".to_string(), "custom/two.json".to_string()]
+        );
+        unsafe {
+            std::env::remove_var("ATI_SKILL_REGISTRY_INDEX_OBJECT");
+        }
+        assert_eq!(default_catalog_index_path(), "_skillati/catalog.v1.json");
+    }
+
+    #[test]
+    fn build_catalog_manifest_collects_nested_resources() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("skills");
+        let skill = root.join("demo-skill");
+        fs::create_dir_all(skill.join("references/components")).unwrap();
+        fs::write(skill.join("SKILL.md"), "# Demo Skill\n\nUseful demo.\n").unwrap();
+        fs::write(
+            skill.join("skill.toml"),
+            "[skill]\nname=\"demo-skill\"\nkeywords=[\"demo\"]\n",
+        )
+        .unwrap();
+        fs::write(
+            skill.join("references/components/example.md"),
+            "nested reference",
+        )
+        .unwrap();
+
+        let manifest = build_catalog_manifest(&root).unwrap();
+        assert_eq!(manifest.skills.len(), 1);
+        assert_eq!(manifest.skills[0].meta.name, "demo-skill");
+        assert_eq!(
+            manifest.skills[0].resources,
+            vec!["references/components/example.md".to_string()]
+        );
+        assert!(manifest.skills[0].resources_complete);
+    }
+
+    #[test]
+    fn collect_visible_resources_skips_internal_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill = tmp.path().join("demo-skill");
+        fs::create_dir_all(skill.join("references")).unwrap();
+        fs::write(skill.join("SKILL.md"), "x").unwrap();
+        fs::write(skill.join("skill.toml"), "x").unwrap();
+        fs::write(skill.join(".hidden"), "x").unwrap();
+        fs::write(skill.join("references/guide.md"), "x").unwrap();
+
+        let resources = collect_visible_resources(&skill, &skill).unwrap();
+        assert_eq!(resources, vec!["references/guide.md".to_string()]);
+    }
+
+    #[test]
+    fn catalog_entry_sorts_and_dedups_resources() {
+        let mut entry = SkillAtiCatalogEntry {
+            meta: remote_skill_meta_from_parts(
+                "demo-skill",
+                "".into(),
+                vec!["b".into(), "a".into(), "A".into()],
+                vec![],
+                vec![],
+                vec![],
+            ),
+            resources: vec![
+                "references/b.md".into(),
+                "SKILL.md".into(),
+                "references/a.md".into(),
+                "references/a.md".into(),
+            ],
+            resources_complete: false,
+        };
+
+        super::normalize_catalog_entry(&mut entry);
+        assert_eq!(entry.meta.keywords, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(
+            entry.resources,
+            vec!["references/a.md".to_string(), "references/b.md".to_string()]
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,10 @@ pub enum Commands {
     #[command(subcommand)]
     Skill(SkillCommands),
 
+    /// Lazily read remote skills from the GCS registry without installing them
+    #[command(name = "skillati", subcommand)]
+    SkillAti(SkillAtiCommands),
+
     /// LLM-powered tool discovery — ask what tool to use
     #[command(name = "assist")]
     Assist {
@@ -275,6 +279,63 @@ pub enum SkillCommands {
         /// Force update even if content hash changed
         #[arg(long)]
         force: bool,
+    },
+    /// View remote skills via the lazy GCS registry
+    Fetch {
+        /// SkillATI-style subcommands (catalog, read, resources, cat, refs, ref, build-index)
+        #[command(subcommand)]
+        fetch: SkillAtiCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SkillAtiCommands {
+    /// List remote skills available from the GCS registry
+    Catalog {
+        /// Optional fuzzy search over remote skill name/description
+        #[arg(long)]
+        search: Option<String>,
+    },
+    /// Read SKILL.md for a remote skill from the GCS registry
+    Read {
+        /// Skill name
+        name: String,
+    },
+    /// List bundled resources for a remote skill without reading file contents
+    Resources {
+        /// Skill name
+        name: String,
+        /// Optional resource prefix to filter on, e.g. references/ or scripts/
+        #[arg(long)]
+        prefix: Option<String>,
+    },
+    /// Read a skill-relative file path, including nested references, scripts, or assets
+    Cat {
+        /// Skill name
+        name: String,
+        /// Skill-relative path, e.g. references/foo.md or ../other-skill/SKILL.md
+        path: String,
+    },
+    /// List available on-demand reference files for a remote skill
+    Refs {
+        /// Skill name
+        name: String,
+    },
+    /// Read a single reference file for a remote skill
+    Ref {
+        /// Skill name
+        name: String,
+        /// Reference file name under references/
+        reference: String,
+    },
+    /// Build a SkillATI catalog manifest from a local skills directory for GCS publishing
+    #[command(name = "build-index")]
+    BuildIndex {
+        /// Directory containing one subdirectory per skill, or a single skill directory
+        source_dir: String,
+        /// Optional file path to write the manifest JSON to
+        #[arg(long = "output-file")]
+        output_file: Option<String>,
     },
 }
 
@@ -578,6 +639,7 @@ async fn main() {
         Commands::Run { tool_name, args } => cli::call::execute(&cli, tool_name, args).await,
         Commands::Tool(subcmd) => cli::tools::execute(&cli, subcmd).await,
         Commands::Skill(subcmd) => cli::skills::execute(&cli, subcmd).await,
+        Commands::SkillAti(subcmd) => cli::skillati::execute(&cli, subcmd).await,
         Commands::Assist {
             args,
             plan,

--- a/src/proxy/client.rs
+++ b/src/proxy/client.rs
@@ -309,6 +309,165 @@ pub async fn get_skill(
         .map_err(|e| ProxyError::InvalidResponse(e.to_string()))
 }
 
+async fn get_proxy_json(proxy_url: &str, path: &str) -> Result<serde_json::Value, ProxyError> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(PROXY_TIMEOUT_SECS))
+        .build()?;
+
+    let url = format!(
+        "{}/{}",
+        proxy_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    );
+
+    let response = build_proxy_request(&client, reqwest::Method::GET, &url)
+        .send()
+        .await?;
+    let status = response.status();
+
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_else(|_| "empty".into());
+        return Err(ProxyError::ProxyResponse {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    response
+        .json()
+        .await
+        .map_err(|e| ProxyError::InvalidResponse(e.to_string()))
+}
+
+async fn get_proxy_json_with_query(
+    proxy_url: &str,
+    path: &str,
+    query: &[(&str, String)],
+) -> Result<serde_json::Value, ProxyError> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(PROXY_TIMEOUT_SECS))
+        .build()?;
+
+    let mut url = format!(
+        "{}/{}",
+        proxy_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    );
+
+    if !query.is_empty() {
+        let params = query
+            .iter()
+            .map(|(key, value)| format!("{key}={}", urlencoding(value)))
+            .collect::<Vec<_>>()
+            .join("&");
+        url.push('?');
+        url.push_str(&params);
+    }
+
+    let response = build_proxy_request(&client, reqwest::Method::GET, &url)
+        .send()
+        .await?;
+    let status = response.status();
+
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_else(|_| "empty".into());
+        return Err(ProxyError::ProxyResponse {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    response
+        .json()
+        .await
+        .map_err(|e| ProxyError::InvalidResponse(e.to_string()))
+}
+
+/// List remote SkillATI skills from the proxy server.
+pub async fn get_skillati_catalog(
+    proxy_url: &str,
+    search: Option<&str>,
+) -> Result<serde_json::Value, ProxyError> {
+    let query = search
+        .map(|value| vec![("search", value.to_string())])
+        .unwrap_or_default();
+    get_proxy_json_with_query(proxy_url, "skillati/catalog", &query).await
+}
+
+/// Read a remote SkillATI skill from the proxy server.
+pub async fn get_skillati_read(
+    proxy_url: &str,
+    name: &str,
+) -> Result<serde_json::Value, ProxyError> {
+    get_proxy_json(proxy_url, &format!("skillati/{}", urlencoding(name))).await
+}
+
+/// List bundled resources for a remote SkillATI skill via the proxy server.
+pub async fn get_skillati_resources(
+    proxy_url: &str,
+    name: &str,
+    prefix: Option<&str>,
+) -> Result<serde_json::Value, ProxyError> {
+    let query = prefix
+        .map(|value| vec![("prefix", value.to_string())])
+        .unwrap_or_default();
+    get_proxy_json_with_query(
+        proxy_url,
+        &format!("skillati/{}/resources", urlencoding(name)),
+        &query,
+    )
+    .await
+}
+
+/// Read one arbitrary skill-relative path from a remote SkillATI skill via the proxy server.
+pub async fn get_skillati_file(
+    proxy_url: &str,
+    name: &str,
+    path: &str,
+) -> Result<serde_json::Value, ProxyError> {
+    get_proxy_json_with_query(
+        proxy_url,
+        &format!("skillati/{}/file", urlencoding(name)),
+        &[("path", path.to_string())],
+    )
+    .await
+}
+
+/// List on-demand references for a remote SkillATI skill via the proxy server.
+pub async fn get_skillati_refs(
+    proxy_url: &str,
+    name: &str,
+) -> Result<serde_json::Value, ProxyError> {
+    get_proxy_json(proxy_url, &format!("skillati/{}/refs", urlencoding(name))).await
+}
+
+/// Read one reference file from a remote SkillATI skill via the proxy server.
+pub async fn get_skillati_ref(
+    proxy_url: &str,
+    name: &str,
+    reference: &str,
+) -> Result<serde_json::Value, ProxyError> {
+    get_proxy_json(
+        proxy_url,
+        &format!(
+            "skillati/{}/ref/{}",
+            urlencoding(name),
+            urlencoding(reference)
+        ),
+    )
+    .await
+}
+
+fn urlencoding(s: &str) -> String {
+    s.replace('%', "%25")
+        .replace(' ', "%20")
+        .replace('#', "%23")
+        .replace('&', "%26")
+        .replace('?', "%3F")
+        .replace('/', "%2F")
+        .replace('=', "%3D")
+}
+
 /// Resolve skills for given scopes via the proxy.
 pub async fn resolve_skills(
     proxy_url: &str,

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -6,7 +6,7 @@
 /// Usage: `ati proxy --port 8080 [--ati-dir ~/.ati]`
 use axum::{
     body::Body,
-    extract::State,
+    extract::{Query, State},
     http::{Request as HttpRequest, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Response},
@@ -29,6 +29,7 @@ use crate::core::mcp_client;
 use crate::core::response;
 use crate::core::scope::ScopeConfig;
 use crate::core::skill::{self, SkillRegistry};
+use crate::core::skillati::{RemoteSkillMeta, SkillAtiClient, SkillAtiError};
 use crate::core::xai;
 
 /// Shared state for the proxy server.
@@ -185,6 +186,23 @@ pub struct SkillResolveRequest {
 #[derive(Debug, Deserialize)]
 pub struct SkillBundleBatchRequest {
     pub names: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct SkillAtiCatalogQuery {
+    #[serde(default)]
+    pub search: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct SkillAtiResourcesQuery {
+    #[serde(default)]
+    pub prefix: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SkillAtiFileQuery {
+    pub path: String,
 }
 
 // --- Tool endpoint types ---
@@ -516,7 +534,7 @@ async fn handle_help(
 
     let scopes = ScopeConfig::unrestricted();
     let resolved_skills = skill::resolve_skills(&state.skill_registry, &state.registry, &scopes);
-    let skills_section = if resolved_skills.is_empty() {
+    let local_skills_section = if resolved_skills.is_empty() {
         String::new()
     } else {
         format!(
@@ -524,6 +542,14 @@ async fn handle_help(
             skill::build_skill_context(&resolved_skills)
         )
     };
+    let remote_query = req
+        .tool
+        .as_ref()
+        .map(|tool| format!("{tool} {}", req.query))
+        .unwrap_or_else(|| req.query.clone());
+    let remote_skills_section =
+        build_remote_skillati_section(&state.keyring, &remote_query, 12).await;
+    let skills_section = merge_help_skill_sections(&[local_skills_section, remote_skills_section]);
 
     // Build system prompt — scoped or unscoped
     let system_prompt = if let Some(ref tool_name) = req.tool {
@@ -1165,6 +1191,169 @@ async fn handle_skills_resolve(
     (StatusCode::OK, Json(Value::Array(json)))
 }
 
+fn skillati_client(keyring: &Keyring) -> Result<SkillAtiClient, SkillAtiError> {
+    match SkillAtiClient::from_env(keyring)? {
+        Some(client) => Ok(client),
+        None => Err(SkillAtiError::NotConfigured),
+    }
+}
+
+async fn handle_skillati_catalog(
+    State(state): State<Arc<ProxyState>>,
+    Query(query): Query<SkillAtiCatalogQuery>,
+) -> impl IntoResponse {
+    tracing::debug!(search = ?query.search, "GET /skillati/catalog");
+
+    let client = match skillati_client(&state.keyring) {
+        Ok(client) => client,
+        Err(err) => return skillati_error_response(err),
+    };
+
+    match client.catalog().await {
+        Ok(catalog) => {
+            let skills = if let Some(search) = query.search.as_deref() {
+                SkillAtiClient::filter_catalog(&catalog, search, 25)
+            } else {
+                catalog
+            };
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "skills": skills,
+                })),
+            )
+        }
+        Err(err) => skillati_error_response(err),
+    }
+}
+
+async fn handle_skillati_read(
+    State(state): State<Arc<ProxyState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    tracing::debug!(%name, "GET /skillati/:name");
+
+    let client = match skillati_client(&state.keyring) {
+        Ok(client) => client,
+        Err(err) => return skillati_error_response(err),
+    };
+
+    match client.read_skill(&name).await {
+        Ok(activation) => (StatusCode::OK, Json(serde_json::json!(activation))),
+        Err(err) => skillati_error_response(err),
+    }
+}
+
+async fn handle_skillati_resources(
+    State(state): State<Arc<ProxyState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+    Query(query): Query<SkillAtiResourcesQuery>,
+) -> impl IntoResponse {
+    tracing::debug!(%name, prefix = ?query.prefix, "GET /skillati/:name/resources");
+
+    let client = match skillati_client(&state.keyring) {
+        Ok(client) => client,
+        Err(err) => return skillati_error_response(err),
+    };
+
+    match client.list_resources(&name, query.prefix.as_deref()).await {
+        Ok(resources) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "name": name,
+                "prefix": query.prefix,
+                "resources": resources,
+            })),
+        ),
+        Err(err) => skillati_error_response(err),
+    }
+}
+
+async fn handle_skillati_file(
+    State(state): State<Arc<ProxyState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+    Query(query): Query<SkillAtiFileQuery>,
+) -> impl IntoResponse {
+    tracing::debug!(%name, path = %query.path, "GET /skillati/:name/file");
+
+    let client = match skillati_client(&state.keyring) {
+        Ok(client) => client,
+        Err(err) => return skillati_error_response(err),
+    };
+
+    match client.read_path(&name, &query.path).await {
+        Ok(file) => (StatusCode::OK, Json(serde_json::json!(file))),
+        Err(err) => skillati_error_response(err),
+    }
+}
+
+async fn handle_skillati_refs(
+    State(state): State<Arc<ProxyState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    tracing::debug!(%name, "GET /skillati/:name/refs");
+
+    let client = match skillati_client(&state.keyring) {
+        Ok(client) => client,
+        Err(err) => return skillati_error_response(err),
+    };
+
+    match client.list_references(&name).await {
+        Ok(references) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "name": name,
+                "references": references,
+            })),
+        ),
+        Err(err) => skillati_error_response(err),
+    }
+}
+
+async fn handle_skillati_ref(
+    State(state): State<Arc<ProxyState>>,
+    axum::extract::Path((name, reference)): axum::extract::Path<(String, String)>,
+) -> impl IntoResponse {
+    tracing::debug!(%name, %reference, "GET /skillati/:name/ref/:reference");
+
+    let client = match skillati_client(&state.keyring) {
+        Ok(client) => client,
+        Err(err) => return skillati_error_response(err),
+    };
+
+    match client.read_reference(&name, &reference).await {
+        Ok(content) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "name": name,
+                "reference": reference,
+                "content": content,
+            })),
+        ),
+        Err(err) => skillati_error_response(err),
+    }
+}
+
+fn skillati_error_response(err: SkillAtiError) -> (StatusCode, Json<Value>) {
+    let status = match &err {
+        SkillAtiError::NotConfigured
+        | SkillAtiError::UnsupportedRegistry(_)
+        | SkillAtiError::MissingCredentials(_) => StatusCode::SERVICE_UNAVAILABLE,
+        SkillAtiError::SkillNotFound(_) | SkillAtiError::PathNotFound { .. } => {
+            StatusCode::NOT_FOUND
+        }
+        SkillAtiError::InvalidPath(_) => StatusCode::BAD_REQUEST,
+        SkillAtiError::Gcs(_) => StatusCode::BAD_GATEWAY,
+    };
+
+    (
+        status,
+        Json(serde_json::json!({
+            "error": err.to_string(),
+        })),
+    )
+}
+
 // --- Auth middleware ---
 
 /// JWT authentication middleware.
@@ -1230,6 +1419,12 @@ pub fn build_router(state: Arc<ProxyState>) -> Router {
         .route("/skills/bundle", post(handle_skills_bundle_batch))
         .route("/skills/{name}", get(handle_skill_detail))
         .route("/skills/{name}/bundle", get(handle_skill_bundle))
+        .route("/skillati/catalog", get(handle_skillati_catalog))
+        .route("/skillati/{name}", get(handle_skillati_read))
+        .route("/skillati/{name}/resources", get(handle_skillati_resources))
+        .route("/skillati/{name}/file", get(handle_skillati_file))
+        .route("/skillati/{name}/refs", get(handle_skillati_refs))
+        .route("/skillati/{name}/ref/{reference}", get(handle_skillati_ref))
         .route("/health", get(handle_health))
         .route("/.well-known/jwks.json", get(handle_jwks))
         .layer(middleware::from_fn_with_state(
@@ -1327,48 +1522,21 @@ pub async fn run(
         .collect();
     let openapi_count = openapi_providers.len();
 
-    // Load skill registry (local + optional GCS)
+    // Load installed/local skill registry only.
     let skills_dir = ati_dir.join("skills");
-    let mut skill_registry = SkillRegistry::load(&skills_dir).unwrap_or_else(|e| {
+    let skill_registry = SkillRegistry::load(&skills_dir).unwrap_or_else(|e| {
         tracing::warn!(error = %e, "failed to load skills");
         SkillRegistry::load(std::path::Path::new("/nonexistent-fallback")).unwrap()
     });
 
-    // Load GCS skills if ATI_SKILL_REGISTRY is set
     if let Ok(registry_url) = std::env::var("ATI_SKILL_REGISTRY") {
-        if let Some(bucket) = registry_url.strip_prefix("gcs://") {
-            let cred_key = "gcp_credentials";
-            if let Some(cred_json) = keyring.get(cred_key) {
-                match crate::core::gcs::GcsClient::new(bucket.to_string(), cred_json) {
-                    Ok(client) => match crate::core::gcs::GcsSkillSource::load(&client).await {
-                        Ok(gcs_source) => {
-                            let gcs_count = gcs_source.skill_count();
-                            skill_registry.merge(gcs_source);
-                            tracing::info!(
-                                bucket = %bucket,
-                                skills = gcs_count,
-                                "loaded skills from GCS registry"
-                            );
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = %e, bucket = %bucket, "failed to load GCS skills");
-                        }
-                    },
-                    Err(e) => {
-                        tracing::warn!(error = %e, "failed to init GCS client");
-                    }
-                }
-            } else {
-                tracing::warn!(
-                    key = %cred_key,
-                    "ATI_SKILL_REGISTRY set but GCS credentials not found in keyring"
-                );
-            }
-        } else {
-            tracing::warn!(
-                url = %registry_url,
-                "unsupported skill registry scheme (only gcs:// is supported)"
+        if registry_url.strip_prefix("gcs://").is_some() {
+            tracing::info!(
+                registry = %registry_url,
+                "SkillATI remote registry configured for lazy reads"
             );
+        } else {
+            tracing::warn!(url = %registry_url, "SkillATI only supports gcs:// registries");
         }
     }
 
@@ -1481,6 +1649,67 @@ Answer the agent's question naturally, like a knowledgeable colleague would. Kee
 - If skills are relevant, suggest `ati skill show <name>` for the full methodology
 
 Keep your answer concise — a few short paragraphs with embedded code blocks. Only recommend tools from the list above."#;
+
+async fn build_remote_skillati_section(keyring: &Keyring, query: &str, limit: usize) -> String {
+    let client = match SkillAtiClient::from_env(keyring) {
+        Ok(Some(client)) => client,
+        Ok(None) => return String::new(),
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to initialize SkillATI catalog for proxy help");
+            return String::new();
+        }
+    };
+
+    let catalog = match client.catalog().await {
+        Ok(catalog) => catalog,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to load SkillATI catalog for proxy help");
+            return String::new();
+        }
+    };
+
+    let matched = SkillAtiClient::filter_catalog(&catalog, query, limit);
+    if matched.is_empty() {
+        return String::new();
+    }
+
+    render_remote_skillati_section(&matched, catalog.len())
+}
+
+fn render_remote_skillati_section(skills: &[RemoteSkillMeta], total_catalog: usize) -> String {
+    let mut section = String::from("## Remote Skills Available Via SkillATI\n\n");
+    section.push_str(
+        "These skills are available remotely from the SkillATI registry. They are not installed locally. Activate one on demand with `ati skillati read <name>`, inspect bundled paths with `ati skillati resources <name>`, and fetch specific files with `ati skillati cat <name> <path>`.\n\n",
+    );
+
+    for skill in skills {
+        section.push_str(&format!("- **{}**: {}\n", skill.name, skill.description));
+    }
+
+    if total_catalog > skills.len() {
+        section.push_str(&format!(
+            "\nOnly the most relevant {} remote skills are shown here.\n",
+            skills.len()
+        ));
+    }
+
+    section
+}
+
+fn merge_help_skill_sections(sections: &[String]) -> String {
+    sections
+        .iter()
+        .filter_map(|section| {
+            let trimmed = section.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
 
 fn build_tool_context(
     tools: &[(

--- a/tests/proxy_server_test.rs
+++ b/tests/proxy_server_test.rs
@@ -18,6 +18,33 @@ use ati::core::manifest::ManifestRegistry;
 use ati::core::skill::SkillRegistry;
 use ati::proxy::server::{build_router, ProxyState};
 
+struct EnvGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: Option<&str>) -> Self {
+        let original = std::env::var(key).ok();
+        if let Some(v) = value {
+            std::env::set_var(key, v);
+        } else {
+            std::env::remove_var(key);
+        }
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(val) = &self.original {
+            std::env::set_var(self.key, val);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
 // --- Helpers ---
 
 /// Create a temp directory with a single manifest pointing at the given upstream base_url.
@@ -1231,4 +1258,49 @@ async fn test_call_underscore_scope_matches_colon_tool() {
     );
     // Should also NOT be 404
     assert_ne!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn skillati_catalog_without_registry_returns_503() {
+    let _env = EnvGuard::set("ATI_SKILL_REGISTRY", None);
+    let app = build_test_app("http://unused.test");
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/skillati/catalog")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn skillati_resources_without_registry_returns_503() {
+    let _env = EnvGuard::set("ATI_SKILL_REGISTRY", None);
+    let app = build_test_app("http://unused.test");
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/skillati/demo/resources")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn skillati_file_without_registry_returns_503() {
+    let _env = EnvGuard::set("ATI_SKILL_REGISTRY", None);
+    let app = build_test_app("http://unused.test");
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/skillati/demo/file?path=SKILL.md")
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/tests/skill_fetch_test.rs
+++ b/tests/skill_fetch_test.rs
@@ -1,0 +1,20 @@
+use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+use predicates::str::contains;
+
+fn ati_cmd() -> Command {
+    let mut cmd = Command::cargo_bin("ati").unwrap();
+    cmd.env_remove("RUST_LOG");
+    cmd
+}
+
+#[test]
+fn skill_fetch_in_proxy_mode_fails_cleanly_instead_of_panicking() {
+    ati_cmd()
+        .env("ATI_PROXY_URL", "http://127.0.0.1:9")
+        .args(["skill", "fetch", "catalog"])
+        .assert()
+        .failure()
+        .stderr(contains("Proxy request failed").or(contains("Connection refused")))
+        .stderr(predicates::str::contains("Non-proxy commands should not reach here").not());
+}

--- a/tests/skillati_cli_test.rs
+++ b/tests/skillati_cli_test.rs
@@ -1,0 +1,68 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::fs;
+
+#[test]
+fn skillati_build_index_writes_manifest_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let skill_dir = dir.path().join("demo-skill");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "# Demo Skill
+
+Details").unwrap();
+    fs::write(
+        skill_dir.join("skill.toml"),
+        r#"[skill]
+name="demo-skill"
+description="Demo"
+"#,
+    )
+    .unwrap();
+
+    let output = dir.path().join("catalog.json");
+
+    Command::new(env!("CARGO_BIN_EXE_ati"))
+        .args(&[
+            "skill",
+            "fetch",
+            "build-index",
+            skill_dir.to_str().unwrap(),
+            "--output-file",
+            output.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(contains("\"skills\": 1"));
+
+    let manifest = fs::read_to_string(&output).unwrap();
+    assert!(manifest.contains("\"name\": \"demo-skill\""));
+}
+
+#[test]
+fn skillati_build_index_prints_json_when_no_output_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let skill_dir = dir.path().join("demo-skill-2");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "# Demo Skill 2
+
+Details").unwrap();
+    fs::write(
+        skill_dir.join("skill.toml"),
+        r#"[skill]
+name="demo-skill-2"
+description="Demo 2"
+"#,
+    )
+    .unwrap();
+
+    Command::new(env!("CARGO_BIN_EXE_ati"))
+        .args(&[
+            "skill",
+            "fetch",
+            "build-index",
+            skill_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(contains("\"name\": \"demo-skill-2\""));
+}


### PR DESCRIPTION
## Summary
- add a lazy remote skill fetch flow backed by the GCS skill registry, including `ati skill fetch ...` and proxy endpoints for catalog, resource listing, and file reads
- keep remote skills out of the installed local skill registry while exposing metadata to assist/help flows
- add manifest/index support plus CLI and proxy regression coverage, including the proxy-mode `skill fetch` panic fix

## Test Results
- `cargo test --quiet`
- `cargo test --quiet --test skill_fetch_test`

## Notes
- remote skill content is fetched lazily and not installed into a user-readable local skill directory
- `_skillati/catalog.v1.json` remains an optional fast-path index for remote catalog discovery
