### PR TITLE
fix(cli): support --key=value syntax in ati run tool args

### DIFF
--- a/src/cli/call.rs
+++ b/src/cli/call.rs
@@ -14,7 +14,7 @@ use crate::providers::generic;
 use crate::proxy::client as proxy_client;
 use crate::Cli;
 
-/// Parse CLI args like --key value --flag into a HashMap.
+/// Parse CLI args like --key value, --key=value, --flag into a HashMap.
 /// Strips known global flags (-J, --json, --verbose, --output) that may be
 /// captured by trailing_var_arg.
 fn parse_tool_args(args: &[String]) -> Result<HashMap<String, Value>, Box<dyn std::error::Error>> {
@@ -28,6 +28,8 @@ fn parse_tool_args(args: &[String]) -> Result<HashMap<String, Value>, Box<dyn st
                 i += 1; // skip flag
             } else if arg == "--output" || arg == "--format" {
                 i += 2; // skip flag + value
+            } else if arg.starts_with("--output=") || arg.starts_with("--format=") {
+                i += 1; // skip inline flag=value form
             } else {
                 result.push(arg);
                 i += 1;
@@ -42,7 +44,23 @@ fn parse_tool_args(args: &[String]) -> Result<HashMap<String, Value>, Box<dyn st
     while i < filtered.len() {
         let arg = &filtered[i];
         if arg.starts_with("--") {
-            let key = arg.trim_start_matches("--").to_string();
+            let stripped = arg.trim_start_matches("--");
+
+            // `--key=value` form: split on the first '=' so the standard
+            // clap-style syntax works instead of producing a boolean flag
+            // literally named "key=value" (and silently dropping the value).
+            if let Some((key, val_str)) = stripped.split_once('=') {
+                if key.is_empty() {
+                    return Err("Empty argument key".into());
+                }
+                let value = serde_json::from_str(val_str)
+                    .unwrap_or_else(|_| Value::String(val_str.to_string()));
+                map.insert(key.to_string(), value);
+                i += 1;
+                continue;
+            }
+
+            let key = stripped.to_string();
             if key.is_empty() {
                 return Err("Empty argument key".into());
             }

--- a/tests/call_test.rs
+++ b/tests/call_test.rs
@@ -43,6 +43,66 @@ fn test_parse_json_value() {
 }
 
 #[test]
+fn test_parse_key_equals_value() {
+    let args = vec![
+        "--file_url=https://example.com/doc.pdf".to_string(),
+        "--parse_mode=auto".to_string(),
+        "--max_results=10".to_string(),
+    ];
+
+    let parsed = parse_tool_args(&args).unwrap();
+    assert_eq!(
+        parsed.get("file_url").unwrap(),
+        &json!("https://example.com/doc.pdf")
+    );
+    assert_eq!(parsed.get("parse_mode").unwrap(), &json!("auto"));
+    assert_eq!(parsed.get("max_results").unwrap(), &json!(10));
+}
+
+#[test]
+fn test_parse_key_equals_json_value() {
+    let args = vec![r#"--formats=["markdown","json"]"#.to_string()];
+
+    let parsed = parse_tool_args(&args).unwrap();
+    assert_eq!(
+        parsed.get("formats").unwrap(),
+        &json!(["markdown", "json"])
+    );
+}
+
+#[test]
+fn test_parse_key_equals_value_containing_equals() {
+    // Only the FIRST '=' separates key from value.
+    let args = vec!["--query=a=b".to_string()];
+
+    let parsed = parse_tool_args(&args).unwrap();
+    assert_eq!(parsed.get("query").unwrap(), &json!("a=b"));
+}
+
+#[test]
+fn test_parse_mixed_equals_and_space_forms() {
+    let args = vec![
+        "--parse_mode=ocr".to_string(),
+        "--query".to_string(),
+        "hello".to_string(),
+        "--verbose_flag".to_string(),
+    ];
+
+    let parsed = parse_tool_args(&args).unwrap();
+    assert_eq!(parsed.get("parse_mode").unwrap(), &json!("ocr"));
+    assert_eq!(parsed.get("query").unwrap(), &json!("hello"));
+    assert_eq!(parsed.get("verbose_flag").unwrap(), &json!(true));
+}
+
+#[test]
+fn test_parse_key_equals_empty_value() {
+    let args = vec!["--note=".to_string()];
+
+    let parsed = parse_tool_args(&args).unwrap();
+    assert_eq!(parsed.get("note").unwrap(), &json!(""));
+}
+
+#[test]
 fn test_parse_empty_args() {
     let args: Vec<String> = vec![];
     let parsed = parse_tool_args(&args).unwrap();
@@ -146,7 +206,20 @@ fn parse_tool_args(args: &[String]) -> Result<HashMap<String, Value>, Box<dyn st
     while i < args.len() {
         let arg = &args[i];
         if arg.starts_with("--") {
-            let key = arg.trim_start_matches("--").to_string();
+            let stripped = arg.trim_start_matches("--");
+
+            if let Some((key, val_str)) = stripped.split_once('=') {
+                if key.is_empty() {
+                    return Err("Empty argument key".into());
+                }
+                let value = serde_json::from_str(val_str)
+                    .unwrap_or_else(|_| Value::String(val_str.to_string()));
+                map.insert(key.to_string(), value);
+                i += 1;
+                continue;
+            }
+
+            let key = stripped.to_string();
             if key.is_empty() {
                 return Err("Empty argument key".into());
             }


### PR DESCRIPTION
## Problem

`parse_tool_args` only splits space-separated `--key value` pairs. The standard clap-style `--key=value` form — which agents reach for constantly — is parsed as a **boolean flag literally named `key=value`**:

```
ati run parcha_custom_tools:firecrawl_parse_document --file_url=https://... --parse_mode=auto
```

produces `{"file_url=https://...": true, "parse_mode=auto": true}` — the tool receives none of the intended arguments, and the only surfaced symptom is a downstream missing-required-argument validation error that agents burn many turns reverse-engineering.

## Fix

- Split `--key=value` on the **first** `=` (values may themselves contain `=`), JSON-decoding the value with string fallback, identical to the space-separated path.
- Strip inline `--output=…` / `--format=…` global flags the same way as their space-separated forms.
- Mirrored the change in the `tests/call_test.rs` helper copy and added coverage: plain `=` pairs, JSON-array values, values containing `=`, mixed `=`/space forms, and empty values.

## Testing

- `cargo test --test call_test`: 15 passed.
- `cargo check`: clean.

## Follow-up (not in this PR)

`ati run <tool> --help` currently forwards `--help` to the tool as an argument instead of printing the tool's schema — worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)