### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you're providing a unified interface for AI agents to access various tools and services, simplifying agent development. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Session permission mode bypasses approvals
   In `agent_tools_interface/src/session.rs`, The `SessionPermissionMode::Allow` does not require approval from the user. 
   This can lead to unauthorized access to sensitive resources and potentially compromise security.
2.  [MEDIUM] Insecure default value for agent logging level
   In `agent_tools_interface/src/agent.rs`, The `logging_level` field in `AgentConfig` defaults to `INFO`. 
   This could expose sensitive information, such as API keys and user data, in the logs.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Parcha-ai/codesmith/ati/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788931753&installation_model_id=431113&pr_number=150&repository=Parcha-ai%2Fati&return_to=https%3A%2F%2Fgithub.com%2FParcha-ai%2Fati%2Fpull%2F150&signature=4a64f2ca4988eb26f53cd54b2a7cf5cdfb19d0e1002c6b68f3701e82d4834c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->